### PR TITLE
docs(data): file-level orientation comments in src/data

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -1,3 +1,32 @@
+/**
+ * Global / shared site content.
+ *
+ * This is the catch-all data file for copy that appears on more than one page,
+ * or that isn't tied to a specific route. Per-page hero copy lives in
+ * `src/data/pages/*.ts`; long-form content (services, articles) lives in
+ * `services.ts` and `resources.ts`; SEO fields live in `metadata.ts`.
+ *
+ * Top-level sections (in order):
+ *   - site            Org name, tagline, contact email, canonical URL
+ *   - navigation      Top-nav links (label + href)
+ *   - services        Heading + "Learn More" label for the homepage services strip
+ *   - clientLogos     Partner-logo strip on the homepage (drop new .webp into
+ *                     /public/images/partner_logos/optimized/ and add an entry)
+ *   - testimonials    PLACEHOLDER quotes (Alex Johnson / Maria Lee / Sam Patel) —
+ *                     stub content kept so the section can be populated later
+ *   - valueProposition  "Our Value Add" cards on the homepage
+ *   - contactCTA      "Ready to Transform Your Organization?" block (homepage + others)
+ *   - footer          Email / LinkedIn / phone + footer logo
+ *   - header          Header logo + mobile menu a11y labels
+ *   - resources       Per-resource title/subtitle overrides (keyed by slug)
+ *   - forms           Contact + newsletter form labels, placeholders, validation
+ *                     messages, and Netlify form names. NOTE: if you add a new
+ *                     field to a React form, also add it to /public/forms.html
+ *                     so Netlify registers it at build time.
+ *   - ui              Shared UI strings: button labels, loading states, error
+ *                     messages, ARIA labels, generic page titles, section
+ *                     headings, share-this-article copy, etc.
+ */
 export const siteContent = {
   // Global site information
   site: {
@@ -84,6 +113,9 @@ export const siteContent = {
   },
 
   // Testimonials section
+  // NOTE: items below are PLACEHOLDER stub quotes (Alex Johnson / Maria Lee /
+  // Sam Patel). Replace with real client quotes before going public, or remove
+  // the section from the homepage if not used.
   testimonials: {
     title: 'What Our Clients Say',
     items: [
@@ -185,6 +217,10 @@ export const siteContent = {
   },
 
   // Forms
+  // Both forms are submitted via Netlify Forms (no backend code). The
+  // `netlifyName` values below MUST match the corresponding hidden form names
+  // in /public/forms.html — that file is what Netlify scans at build to
+  // register the forms and their fields.
   forms: {
     contact: {
       title: 'Contact Form',

--- a/src/data/metadata.ts
+++ b/src/data/metadata.ts
@@ -1,3 +1,31 @@
+/**
+ * SEO / social-sharing metadata for every page.
+ *
+ * This is what populates <title>, <meta name="description">, Open Graph tags,
+ * Twitter Card tags, and the JSON-LD organization schema. Visible on-page copy
+ * lives elsewhere — this file is purely for what search engines and social
+ * previews see.
+ *
+ * Sections:
+ *   - default         Fallback title/description/keywords/og-image for any page
+ *                     that doesn't override them
+ *   - pages           Per-route overrides keyed by page name (home, about,
+ *                     services, contact, resources, privacy, …)
+ *   - services        Per-service-detail-page overrides, keyed by the same
+ *                     slug used in `src/data/services.ts`. KEEP IN SYNC: when
+ *                     you add a service there, add a matching entry here.
+ *   - resources       Per-article overrides, keyed by the same slug used in
+ *                     `src/data/resources.ts`. KEEP IN SYNC the same way.
+ *   - openGraph       Default Open Graph card (used when sharing on LinkedIn,
+ *                     Facebook, Slack, etc.)
+ *   - twitter         Twitter/X card defaults
+ *   - organization    schema.org Organization JSON-LD (rendered into the page
+ *                     for rich-result eligibility). Update logo/contact here
+ *                     if the brand changes.
+ *
+ * Note: the `url` field on each entry should be the absolute canonical URL
+ * (https://autiostrategies.com/...) — used for og:url and link rel="canonical".
+ */
 export const siteMetadata = {
   // Default metadata
   default: {

--- a/src/data/pages/about.ts
+++ b/src/data/pages/about.ts
@@ -1,3 +1,17 @@
+/**
+ * About page content.
+ *
+ * Sections:
+ *   - hero         Page title + responsive background image variants
+ *   - body         "What we do" intro paragraph
+ *   - teamSection  Heading shown above the team grid
+ *   - team         Team bios + headshots, keyed by first name
+ *                  (chloe / samuel / chaerin). To add a team member, add a new
+ *                  key with the same shape and drop their headshot into
+ *                  /public/images/headshot/optimized/ (run
+ *                  `npm run optimize-headshots` first).
+ *   - cta          "Partner with Our Team" call-to-action at the bottom
+ */
 export const aboutContent = {
   hero: {
     title: 'About Us',

--- a/src/data/pages/contact.ts
+++ b/src/data/pages/contact.ts
@@ -1,3 +1,10 @@
+/**
+ * Contact page hero only.
+ *
+ * The contact form itself (labels, placeholders, validation messages, and
+ * Netlify form name) is in `src/data/content.ts` under `forms.contact`.
+ * Footer email/phone/LinkedIn live there too under `footer.contact`.
+ */
 export const contactContent = {
   hero: {
     title: 'Contact Us',

--- a/src/data/pages/home.ts
+++ b/src/data/pages/home.ts
@@ -1,3 +1,14 @@
+/**
+ * Homepage hero only.
+ *
+ * The rest of the homepage (testimonials, value-prop cards, partner logos,
+ * "Ready to Transform" CTA) is shared content and lives in
+ * `src/data/content.ts`. The services strip pulls from `src/data/services.ts`.
+ *
+ * `background.image` is the default hero source; `variants` provides
+ * responsive small/medium/large .webp paths. Drop new images into
+ * /public/images/stocks/optimized/ and run `npm run optimize-images`.
+ */
 export const homeContent = {
   hero: {
     title: 'AI Policy Solutions',

--- a/src/data/pages/index.ts
+++ b/src/data/pages/index.ts
@@ -1,3 +1,6 @@
+// Barrel re-exports for per-page hero / page-specific content.
+// Edit the individual files in this folder to change page copy; route files
+// under `src/app/` import from here.
 export { homeContent } from './home';
 export { aboutContent } from './about';
 export { servicesContent } from './services';

--- a/src/data/pages/resources.ts
+++ b/src/data/pages/resources.ts
@@ -1,3 +1,10 @@
+/**
+ * Insights index page hero only.
+ *
+ * The articles/policy briefs/case studies that fill this page live in
+ * `src/data/resources.ts`. Per-article SEO metadata lives in
+ * `src/data/metadata.ts` under `resources.{slug}`.
+ */
 export const resourcesContent = {
   hero: {
     title: 'Insights',

--- a/src/data/pages/services.ts
+++ b/src/data/pages/services.ts
@@ -1,3 +1,10 @@
+/**
+ * Services index page hero only.
+ *
+ * The actual list of service offerings (cards + detail pages) lives in
+ * `src/data/services.ts`. Each individual /services/[slug] detail page uses
+ * its own background from that file, not this one.
+ */
 export const servicesContent = {
   hero: {
     title: 'Services',

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -1,3 +1,31 @@
+/**
+ * Insights / resources content.
+ *
+ * Powers the /insights index page and each /insights/[slug] detail page.
+ * Four content types are defined; today only `articles` is populated and the
+ * other three are intentionally empty arrays so the team can drop content in
+ * later without code changes.
+ *
+ * Exports:
+ *   - authors         Reusable author/source bios. `articles[].author` references
+ *                     entries here by index (e.g., authors[1] = WSJ).
+ *   - articles        News-style insights. Items with `featured: true` surface
+ *                     on the homepage / featured sections. `externalUrl`, when
+ *                     present, makes the card link out instead of rendering a
+ *                     local detail page (used for syndicated WSJ/POLITICO/Fortune
+ *                     coverage).
+ *   - policyBriefs    PLACEHOLDER — empty; type defined so briefs can be added
+ *                     without code changes. Each brief also needs a matching
+ *                     `resources.{slug}` entry in `metadata.ts`.
+ *   - caseStudies     PLACEHOLDER — empty; same pattern as policyBriefs.
+ *   - resources       PLACEHOLDER — empty; generic external links (reports,
+ *                     toolkits, datasets, guidelines) for the resources library.
+ *
+ * To add a new article:
+ *   1. Append to `articles` with a unique kebab-case `slug`.
+ *   2. Add a `resources.{slug}` entry in `src/data/metadata.ts` for SEO.
+ *   3. Use ISO `YYYY-MM-DD` for `date` (sorting + display rely on it).
+ */
 export interface Author {
   name: string;
   title: string;

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -1,3 +1,32 @@
+/**
+ * Service offerings.
+ *
+ * Each entry in `services` becomes:
+ *   - a card on the /services index page, and
+ *   - a detail page at /services/[slug] (route auto-generated from `slug`)
+ *
+ * To add a new service:
+ *   1. Add a new object to the `services` array below (slug must be URL-safe,
+ *      kebab-case, and unique).
+ *   2. Add a matching `services.{slug}` entry in `src/data/metadata.ts` for SEO.
+ *   3. Drop hero background images into /public/images/stocks/optimized/ and
+ *      run `npm run optimize-images` so the small/medium/large .webp variants
+ *      exist before referencing them.
+ *
+ * Field guide:
+ *   - slug                URL segment (also used to look up related services)
+ *   - title / overview    Card heading + one-line summary
+ *   - benefits            Bullet list rendered on the detail page
+ *   - methodology         Paragraph rendered under "Our Methodology"
+ *   - related             Slugs of other services to cross-link at the bottom
+ *                         of the detail page (e.g. ['policy-development'])
+ *   - backgroundImage     Hero image path; `backgroundVariants` provides the
+ *                         responsive small/medium/large sources
+ *   - backgroundPosition  Optional CSS object-position to nudge the hero crop
+ *   - detailedContent     Optional bullets shown above the methodology. HTML
+ *                         is allowed (used for <strong> bold lead-ins) — this
+ *                         is rendered as raw markup so keep it trusted.
+ */
 export interface Service {
   slug: string;
   title: string;


### PR DESCRIPTION
## Summary

Stacked on top of #7. Adds a file-level header comment to each `src/data/*.ts` content file so an editor can open one of them and immediately see:

- what the file is responsible for
- the major sections in order
- cross-file dependencies (e.g. `services.ts` ↔ `metadata.ts`, forms ↔ `public/forms.html`)
- which entries are placeholder/stub content (testimonials)

No runtime changes — comments only.

### Files touched
- `src/data/content.ts`, `metadata.ts`, `services.ts`, `resources.ts`
- `src/data/pages/{home,about,services,resources,contact,index}.ts`

## Review note
Base is `claude/pre-handoff-cleanup-lpGw1` (PR #7). Diff shown here is only the +170-line comments commit. Merge #7 first; this PR will then retarget to `main` automatically.

## Test plan
- [ ] `npm run type-check` passes (comments shouldn't affect TS)
- [ ] `npm run build` succeeds

https://claude.ai/code/session_01QShP2RYnZGymfeb2rpY7r2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QShP2RYnZGymfeb2rpY7r2)_